### PR TITLE
Protect key routes with NextAuth middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,24 +1,11 @@
-// Temporarily disabled authentication for demo purposes
-// import { withAuth } from 'next-auth/middleware';
+import { withAuth } from 'next-auth/middleware';
+import { NextResponse } from 'next/server';
 
-// export default withAuth(
-//   function middleware() {
-//     // Add any additional middleware logic here
-//   },
-//   {
-//     callbacks: {
-//       authorized: ({ token, req }) => {
-//         // Allow all requests for demo
-//         return true;
-//       },
-//     },
-//   }
-// );
-
-// Allow all requests for demo
-export function middleware() {
-  return;
-}
+export default withAuth(function middleware(req) {
+  if (!req.nextauth?.token) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+});
 
 export const config = {
   matcher: ['/dashboard/:path*', '/api/mood/:path*', '/api/insights/:path*'],


### PR DESCRIPTION
## Summary
- secure dashboard and API routes with NextAuth middleware returning 401 for unauthenticated access

## Testing
- `npm test` *(fails: Cannot find module 'node-mocks-http' and other test failures)*
- `npm run lint` *(fails: numerous Prettier and ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689db2ba22a4832c934dc5925d8a817d