### PR TITLE
Document NextAuth env vars and enforce runtime checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ npx prisma db push
 cp .env.example .env
 ```
 
-ערכו את הקובץ `.env` עם הערכים המתאימים.
+ערכו את הקובץ `.env` עם הערכים המתאימים והגדירו:
+
+- `NEXTAUTH_URL` - כתובת הבסיס של האפליקציה (למשל `http://localhost:3000`)
+- `NEXTAUTH_SECRET` - מחרוזת אקראית חזקה להצפנת נתוני NextAuth
 
 5. **הרצת האפליקציה**
 

--- a/env.example
+++ b/env.example
@@ -17,3 +17,9 @@ NODE_ENV=development
 # NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_URL=http://localhost:9099
 # NEXT_PUBLIC_FIREBASE_FIRESTORE_EMULATOR_URL=http://localhost:8080
 # NEXT_PUBLIC_FIREBASE_STORAGE_EMULATOR_URL=http://localhost:9199
+
+# NextAuth configuration
+# URL where NextAuth is running (e.g. http://localhost:3000)
+NEXTAUTH_URL=http://localhost:3000
+# Secret used to encrypt NextAuth tokens. Generate a strong random string.
+NEXTAUTH_SECRET=your-nextauth-secret

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,8 +1,21 @@
 import CredentialsProvider from 'next-auth/providers/credentials';
+import type { NextAuthOptions } from 'next-auth';
 import { prisma } from './db';
 import bcrypt from 'bcryptjs';
 
-export const authOptions = {
+const nextAuthUrl = process.env.NEXTAUTH_URL;
+const nextAuthSecret = process.env.NEXTAUTH_SECRET;
+
+if (!nextAuthUrl) {
+  console.warn('NEXTAUTH_URL is not defined');
+}
+
+if (!nextAuthSecret) {
+  console.warn('NEXTAUTH_SECRET is not defined');
+}
+
+export const authOptions: NextAuthOptions = {
+  secret: nextAuthSecret,
   providers: [
     CredentialsProvider({
       name: 'credentials',


### PR DESCRIPTION
## Summary
- add `NEXTAUTH_URL` and `NEXTAUTH_SECRET` examples
- validate `NEXTAUTH_URL` and `NEXTAUTH_SECRET` in auth options
- document how to configure NextAuth environment variables

## Testing
- `npm test` *(fails: Cannot find module '@/lib/db'; Cannot find module 'node-mocks-http'; mood component tests failing; insights tests failing)*
- `npm run lint` *(fails: many `Unexpected any` and formatting errors)*

------
https://chatgpt.com/codex/tasks/task_e_689db2beeb0c832cab06b773961d257b