### PR TITLE
refactor: simplify route params handling

### DIFF
--- a/src/app/api/insights/[id]/route.ts
+++ b/src/app/api/insights/[id]/route.ts
@@ -16,9 +16,9 @@ const insightUpdateSchema = z.object({
 // PATCH /api/insights/[id] - Update specific insight
 export async function PATCH(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
-  const { id } = await params;
+  const { id } = params;
   try {
     const session = await getServerSession(authOptions);
 
@@ -26,7 +26,6 @@ export async function PATCH(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { id } = await params;
     const body = await request.json();
 
     // Validate input
@@ -72,9 +71,9 @@ export async function PATCH(
 // DELETE /api/insights/[id] - Delete specific insight
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
-  const { id } = await params;
+  const { id } = params;
   try {
     const session = await getServerSession(authOptions);
 

--- a/src/app/api/journal/[id]/route.ts
+++ b/src/app/api/journal/[id]/route.ts
@@ -17,9 +17,9 @@ const journalUpdateSchema = z.object({
 // GET /api/journal/[id] - Get a specific journal entry
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
-  const { id } = await params;
+  const { id } = params;
   try {
     // Temporarily disabled authentication for demo
     // const session = await getServerSession(authOptions);
@@ -86,9 +86,9 @@ export async function GET(
 // PUT /api/journal/[id] - Update a specific journal entry
 export async function PUT(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
-  const { id } = await params;
+  const { id } = params;
   try {
     // Temporarily disabled authentication for demo
     // const session = await getServerSession(authOptions);
@@ -183,9 +183,9 @@ export async function PUT(
 // DELETE /api/journal/[id] - Delete a specific journal entry
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
-  const { id } = await params;
+  const { id } = params;
   try {
     // Temporarily disabled authentication for demo
     // const session = await getServerSession(authOptions);

--- a/src/app/api/mood/[id]/route.ts
+++ b/src/app/api/mood/[id]/route.ts
@@ -13,9 +13,9 @@ const moodUpdateSchema = z.object({
 // GET /api/mood/[id] - Get a specific mood entry
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
-  const { id } = await params;
+  const { id } = params;
   try {
     const session = await getServerSession(authOptions);
     if (!session?.user?.id) {
@@ -73,9 +73,9 @@ export async function GET(
 // PUT /api/mood/[id] - Update a specific mood entry
 export async function PUT(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
-  const { id } = await params;
+  const { id } = params;
   try {
     const session = await getServerSession(authOptions);
     if (!session?.user?.id) {
@@ -153,9 +153,9 @@ export async function PUT(
 // DELETE /api/mood/[id] - Delete a specific mood entry
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
-  const { id } = await params;
+  const { id } = params;
   try {
     const session = await getServerSession(authOptions);
     if (!session?.user?.id) {


### PR DESCRIPTION
## Summary
- refactor mood API handlers to accept params directly instead of awaiting
- update journal and insights API routes to use synchronous params

## Testing
- `npm test src/test/api/mood.test.ts` *(fails: Cannot find module 'node-mocks-http')*
- `npm run lint` *(fails: numerous prettier/eslint errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_689db2c6e76c832c9622500ec81f66fc